### PR TITLE
variable naming updates to align with PyGEM v1.0.3 push

### DIFF
--- a/advanced_test.ipynb
+++ b/advanced_test.ipynb
@@ -296,10 +296,10 @@
     "You are now ready to run an MCMC simulation. We’ll skip the simulation for the reference period and go directly to running a future simulation. The following parameters should either be set within your configuration file, or passed to the *run_simulation* script as command line arguments:\n",
     "<pre>\n",
     "glac_no =               15.03733\n",
-    "gcm_name =              CESM2\n",
-    "scenario =              ssp245\n",
-    "gcm_startyear =         2000\n",
-    "gcm_endyear =           2100\n",
+    "sim_climate_name =      CESM2\n",
+    "sim_climate_scenario =  ssp245\n",
+    "sim_startyear =         2000\n",
+    "sim_endyear =           2100\n",
     "option_calibration =    MCMC\n",
     "nsims =                 50\n",
     "option_dynamics =       OGGM\n",
@@ -344,7 +344,7 @@
     "# passing the above parameters as command line arguments:\n",
     "gcm_name = 'CESM2'\n",
     "scenario = 'ssp245'\n",
-    "!run_simulation -rgi_glac_number {glac_no} -gcm_name {gcm_name} -scenario {scenario} -gcm_startyear 2000 -gcm_endyear 2100 -option_calibration MCMC -nsims 50 -option_dynamics OGGM -use_reg_glena False"
+    "!run_simulation -rgi_glac_number {glac_no} -sim_climate_name {gcm_name} -sim_climate_scenario {scenario} -sim_startyear 2000 -sim_endyear 2100 -option_calibration MCMC -nsims 50 -option_dynamics OGGM -use_reg_glena False"
    ]
   },
   {

--- a/advanced_test_tw.ipynb
+++ b/advanced_test_tw.ipynb
@@ -450,10 +450,10 @@
     "\n",
     "<pre>\n",
     "glac_no =                   1.03622\n",
-    "gcm_name =                  CESM2\n",
-    "scenario =                  ssp245\n",
-    "gcm_startyear =             2000\n",
-    "gcm_endyear =               2100\n",
+    "sim_climate_name =          CESM2\n",
+    "sim_climate_scenario =      ssp245\n",
+    "sim_startyear =             2000\n",
+    "sim_endyear =               2100\n",
     "option_calibration =        MCMC\n",
     "nsims =                     50\n",
     "option_dynamics =           OGGM\n",
@@ -490,7 +490,7 @@
     "# passing the above parameters as command line arguments:\n",
     "gcm_name = 'CESM2'\n",
     "scenario = 'ssp245'\n",
-    "!run_simulation -rgi_glac_number {glac_no} -gcm_name {gcm_name} -scenario {scenario} -gcm_startyear 2000 -gcm_endyear 2100 -option_calibration MCMC -nsims 50 -option_dynamics OGGM -use_reg_glena False"
+    "!run_simulation -rgi_glac_number {glac_no} -sim_climate_name {gcm_name} -sim_climate_scenario {scenario} -sim_startyear 2000 -sim_endyear 2100 -option_calibration MCMC -nsims 50 -option_dynamics OGGM -use_reg_glena False"
    ]
   },
   {

--- a/analyze_mcmc.ipynb
+++ b/analyze_mcmc.ipynb
@@ -83,7 +83,7 @@
    "source": [
     ">**Note:** if a warning appears in the cell above, run MCMC calibration like so:\n",
     "```bash\n",
-    "!run_calibration -rgi_glac_number {glac_no} -ref_startyear 2000 -ref_endyear 2019 -ref_gcm_name ERA5 -option_calibration MCMC\n",
+    "!run_calibration -rgi_glac_number {glac_no} -ref_startyear 2000 -ref_endyear 2019 -ref_climate_name ERA5 -option_calibration MCMC\n",
     "```"
    ]
   },

--- a/analyze_mcmc_regional.ipynb
+++ b/analyze_mcmc_regional.ipynb
@@ -108,7 +108,7 @@
     "chain_length = 10000        # length of each MCMC chain. we have found 10-20k to be sufficient for chain convergence and a desireable effective sample size\n",
     "num_chains= 3               # number of MCMC chains. we will run 3 to test the convergence between and across chains\n",
     "### comment/uncomment the following line depending on whether or not MCMC calibration was already completed for specified region with the above parameters ###\n",
-    "# !run_calibration -rgi_region01 {region} -ref_startyear 2000 -ref_endyear 2019 -ref_gcm_name ERA5 -option_calibration {calib_opt} -chain_length {chain_length} -nchains {num_chains} -ncores {num_cores}"
+    "# !run_calibration -rgi_region01 {region} -ref_startyear 2000 -ref_endyear 2019 -ref_climate_name ERA5 -option_calibration {calib_opt} -chain_length {chain_length} -nchains {num_chains} -ncores {num_cores}"
    ]
   },
   {

--- a/analyze_regional_change.ipynb
+++ b/analyze_regional_change.ipynb
@@ -152,7 +152,7 @@
    "outputs": [],
    "source": [
     "# compile\n",
-    "!postproc_compile_simulations -rgi_region01 {region} -gcm_name {' '.join(gcms)} -scenario {' '.join(scenarios)} -gcm_startyear {startyr} -gcm_endyear {endyr} -option_calibration {calib} -ncores 3 > compile_log.txt"
+    "!postproc_compile_simulations -rgi_region01 {region} -sim_climate_name {' '.join(gcms)} -sim_climate_scenario {' '.join(scenarios)} -sim_startyear {startyr} -sim_endyear {endyr} -option_calibration {calib} -ncores 3 > compile_log.txt"
    ]
   },
   {
@@ -204,7 +204,7 @@
     ">If only specific variables are required, these could have been passed as arguments (space-delimited), e.g. for compiling glacier mass, area, and runoff:\n",
     "\n",
     "```bash\n",
-    "!postproc_compile_simulations -rgi_region01 {region} -gcm_name {' '.join(gcms)} -scenario {' '.join(scenarios)} -gcm_startyear {startyr} -gcm_endyear {endyr} -option_calibration {calib} -ncores 3  -vars glac_mass_monthly glac_area_annual glac_runoff_monthly\n",
+    "!postproc_compile_simulations -rgi_region01 {region} -sim_climate_name {' '.join(gcms)} -sim_climate_scenario {' '.join(scenarios)} -sim_startyear {startyr} -sim_endyear {endyr} -option_calibration {calib} -ncores 3  -vars glac_mass_monthly glac_area_annual glac_runoff_monthly\n",
     "```"
    ]
   },

--- a/run_calibration.ipynb
+++ b/run_calibration.ipynb
@@ -70,7 +70,7 @@
     "# specify some variables that will remain constant for each calibration option\n",
     "yr0=2000    # reference period startyear\n",
     "yr1=2019    # reference period endyear\n",
-    "gcm='ERA5'  # reference period GCM"
+    "ref_clim='ERA5'  # reference period climate"
    ]
   },
   {
@@ -89,7 +89,7 @@
    "source": [
     "# call run calibration\n",
     "calib_opt = 'HH2015'\n",
-    "!run_calibration -rgi_glac_number {glac_no} -ref_startyear {yr0} -ref_endyear {yr1} -ref_gcm_name {gcm} -option_calibration {calib_opt}"
+    "!run_calibration -rgi_glac_number {glac_no} -ref_startyear {yr0} -ref_endyear {yr1} -ref_climate_name {ref_clim} -option_calibration {calib_opt}"
    ]
   },
   {
@@ -125,7 +125,7 @@
    "source": [
     "# call run_calibration\n",
     "calib_opt = 'HH2015mod'\n",
-    "!run_calibration -rgi_glac_number {glac_no} -ref_startyear {yr0} -ref_endyear {yr1} -ref_gcm_name {gcm} -option_calibration {calib_opt}"
+    "!run_calibration -rgi_glac_number {glac_no} -ref_startyear {yr0} -ref_endyear {yr1} -ref_climate_name {ref_clim} -option_calibration {calib_opt}"
    ]
   },
   {
@@ -159,7 +159,7 @@
    "source": [
     "# call run_calibration\n",
     "calib_opt = 'emulator'\n",
-    "!run_calibration -rgi_glac_number {glac_no} -ref_startyear {yr0} -ref_endyear {yr1} -ref_gcm_name {gcm} -option_calibration {calib_opt}"
+    "!run_calibration -rgi_glac_number {glac_no} -ref_startyear {yr0} -ref_endyear {yr1} -ref_climate_name {ref_clim} -option_calibration {calib_opt}"
    ]
   },
   {
@@ -239,7 +239,7 @@
     "calib_opt = 'emulator'\n",
     "region = 6\n",
     "num_cores=8     # change depending on how many cores you have/want to utilize\n",
-    "!run_calibration -rgi_region01 {region} -ref_startyear {yr0} -ref_endyear {yr1} -ref_gcm_name {gcm} -option_calibration {calib_opt} -ncores {num_cores}"
+    "!run_calibration -rgi_region01 {region} -ref_startyear {yr0} -ref_endyear {yr1} -ref_climate_name {ref_clim} -option_calibration {calib_opt} -ncores {num_cores}"
    ]
   },
   {
@@ -302,7 +302,7 @@
     "# to demonstrate, we'll simply cut the chain_length down - 10,000 to 20,000 samples is advisable for proper calibration and chain convergence\n",
     "calib_opt = 'MCMC'\n",
     "chain_length = 100\n",
-    "!run_calibration -rgi_region01 {region} -ref_startyear {yr0} -ref_endyear {yr1} -ref_gcm_name {gcm} -option_calibration {calib_opt} -chain_length {chain_length} -ncores {num_cores}"
+    "!run_calibration -rgi_region01 {region} -ref_startyear {yr0} -ref_endyear {yr1} -ref_climate_name {ref_clim} -option_calibration {calib_opt} -chain_length {chain_length} -ncores {num_cores}"
    ]
   },
   {
@@ -311,7 +311,7 @@
    "source": [
     ">**Note:** if MCMC calibration is only desired for a single glacier (or list of glacier ids), see the below example:<br>\n",
     "```bash\n",
-    "!run_calibration -rgi_glac_number {glac_no} -ref_startyear {yr0} -ref_endyear {yr1} -ref_gcm_name {gcm} -option_calibration {calib_opt} -chain_length {chain_length}\n",
+    "!run_calibration -rgi_glac_number {glac_no} -ref_startyear {yr0} -ref_endyear {yr1} -ref_climate_name {ref_clim} -option_calibration {calib_opt} -chain_length {chain_length}\n",
     "```"
    ]
   },

--- a/run_simulation.ipynb
+++ b/run_simulation.ipynb
@@ -122,7 +122,7 @@
    "source": [
     "for gcm in gcms:\n",
     "    for scenario in scenarios:\n",
-    "        !run_simulation -rgi_glac_number {glac_no} -gcm_startyear 2000 -gcm_endyear 2100 -gcm_name {gcm} -scenario {scenario} -option_calibration MCMC -option_dynamics OGGM -export_binned_data"
+    "        !run_simulation -rgi_glac_number {glac_no} -sim_startyear 2000 -sim_endyear 2100 -sim_climate_name {gcm} -sim_climate_scenario {scenario} -option_calibration MCMC -option_dynamics OGGM -export_binned_data"
    ]
   },
   {
@@ -454,7 +454,7 @@
     "num_cores = 8           # change depending on how many cores you have/want to utilize\n",
     "for gcm in gcms:\n",
     "    for scenario in scenarios:\n",
-    "        !run_simulation -rgi_region01 6 -gcm_startyear 2000 -gcm_endyear 2100 -gcm_name {gcm} -scenario {scenario} -option_calibration MCMC -option_dynamics OGGM -ncores {num_cores}"
+    "        !run_simulation -rgi_region01 6 -sim_startyear 2000 -sim_endyear 2100 -sim_climate_name {gcm} -sim_climate_scenario {scenario} -option_calibration MCMC -option_dynamics OGGM -ncores {num_cores}"
    ]
   },
   {

--- a/simple_test.ipynb
+++ b/simple_test.ipynb
@@ -260,9 +260,9 @@
     "Perform a simple present-day simulation over the 2000-2020 period. Check/change the following parameters in the configuration file, or pass them as command line arguments to *run_simulation*\n",
     "<pre>\n",
     "glac_no =               15.03733\n",
-    "gcm_name =              ERA5\n",
-    "gcm_startyear =         2000\n",
-    "gcm_endyear =           2019\n",
+    "sim_climate_name =      ERA5\n",
+    "sim_startyear =         2000\n",
+    "sim_endyear =           2019\n",
     "option_calibration =    HH2015\n",
     "option_dynamics =       OGGM\n",
     "use_reg_glena =         False         \n",
@@ -433,7 +433,7 @@
    "source": [
     "# passing the above parameters as command line arguments:\n",
     "gcm_name = 'ERA5'\n",
-    "!run_simulation -rgi_glac_number {glac_no} -gcm_name {gcm_name} -gcm_startyear 2000 -gcm_endyear 2019 -option_calibration HH2015 -option_dynamics OGGM -use_reg_glena False"
+    "!run_simulation -rgi_glac_number {glac_no} -sim_climate_name {gcm_name} -sim_startyear 2000 -sim_endyear 2019 -option_calibration HH2015 -option_dynamics OGGM -use_reg_glena False"
    ]
   },
   {
@@ -470,10 +470,10 @@
     "Now run a simple future simulation from 2000 to 2100 using the CESM2 climate model. Check/change the following parameters in the configuration file, or pass them as command line arguments to *run_simulation*\n",
     "<pre>\n",
     "glac_no =               15.03733\n",
-    "gcm_name =              CESM2\n",
-    "scenario =              ssp245\n",
-    "gcm_startyear =         2000\n",
-    "gcm_endyear =           2100\n",
+    "sim_climate_name =      CESM2\n",
+    "sim_climate_scenario =  ssp245\n",
+    "sim_startyear =         2000\n",
+    "sim_endyear =           2100\n",
     "option_calibration =    HH2015\n",
     "option_dynamics =       OGGM\n",
     "use_reg_glena =         False         \n",
@@ -517,7 +517,7 @@
     "# passing the above parameters as command line arguments:\n",
     "gcm_name = 'CESM2'\n",
     "scenario = 'ssp245'\n",
-    "!run_simulation -rgi_glac_number {glac_no} -gcm_name {gcm_name} -scenario {scenario} -gcm_startyear 2000 -gcm_endyear 2100 -option_calibration HH2015 -option_dynamics OGGM -use_reg_glena False"
+    "!run_simulation -rgi_glac_number {glac_no} -sim_climate_name {gcm_name} -sim_climate_scenario {scenario} -sim_startyear 2000 -sim_endyear 2100 -option_calibration HH2015 -option_dynamics OGGM -use_reg_glena False"
    ]
   },
   {


### PR DESCRIPTION
Several variables updated throughout notebooks to align with PyGEM PR [#101](https://github.com/PyGEM-Community/PyGEM/pull/101).

`ref_gcm_name` -> `ref_climate_name`
`gcm_name` -> `sim_climate_name`
`scenario` -> `sim_climate_scenario`
`gcm_startyear` -> `sim_startyear`
`gcm_endyear` -> `sim_endyear`